### PR TITLE
[#100932944] Podcast media stat endpoint requires authenticated user to access.

### DIFF
--- a/config/policies.js
+++ b/config/policies.js
@@ -46,6 +46,7 @@ module.exports.policies = {
   },
 
   podcastmedia: {
+    'stat': true,
     'subscribe': true,
     'related': true
   },


### PR DESCRIPTION
We have a new stats endpoint that is keeping track of podcast media requests. This was created without anonymous access, however, and is causing elevated error rates due to the 401 error codes returned from anonymous users.