### PR TITLE
[#101092694] Vimeo sync does not trigger socket to update episodes in real-time.

### DIFF
--- a/api/services/VimeoStorageSync.js
+++ b/api/services/VimeoStorageSync.js
@@ -194,6 +194,8 @@ vimeo.podcastMediaUpsert = function(video, podcast) {
       });
     }
 
+    var createdAtDate = new Date();
+
     PodcastMedia.findOrCreate({
       uuid: videoId,
       podcast: podcast.id
@@ -209,6 +211,14 @@ vimeo.podcastMediaUpsert = function(video, podcast) {
       podcast: podcast.id
     }, function podcastMediaCreated(err, media) {
       if (err) sails.log.error(err);
+
+      if (Date(media.createdAt) >= createdAtDate) {
+        PodcastMedia.publishCreate(media);
+      }
+      else {
+        PodcastMedia.publishUpdate(media.id, media);
+      }
+
       resolve();
     });
   });

--- a/assets/shared/socketService.js
+++ b/assets/shared/socketService.js
@@ -70,7 +70,11 @@ angular.module('Bethel.util').service('sailsSocket', ['$q', '$rootScope', functi
 
       for (var i = 0, len = editableFields.length; i < len; i++) {
         var field = editableFields[i];
-        if (newValue[field] === oldValue[field]) continue;
+
+        if (angular.isUndefined(newValue[field]) || angular.isUndefined(oldValue[field]) || newValue[field].toString() == oldValue[field].toString()) {
+          continue;
+        }
+
         payload[field] = newValue[field];
       }
 

--- a/assets/shared/socketService.js
+++ b/assets/shared/socketService.js
@@ -111,7 +111,7 @@ angular.module('Bethel.util').service('sailsSocket', ['$q', '$rootScope', functi
       }
 
       $rootScope.$apply();
-      cb();
+      if (typeof cb === 'function') cb();
     });
   };
 
@@ -147,7 +147,7 @@ angular.module('Bethel.util').service('sailsSocket', ['$q', '$rootScope', functi
 
       }
       $rootScope.$apply();
-      cb();
+      if (typeof cb === 'function') cb();
     });
   };
 

--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,7 @@
   "private": true,
   "dependencies": {
     "angular": "~1.4",
+    "angular-animate": "~1.4",
     "angular-chart.js": "~0.7.2",
     "angular-dom": "master",
     "angular-google-maps": "~2.0.11",

--- a/tasks/pipeline.js
+++ b/tasks/pipeline.js
@@ -36,6 +36,7 @@ var jsFilesToInject = [
   'components/moment/min/moment.min.js',
 
   // Angular dependencies
+  'components/angular-animate/angular-animate.min.js',
   'components/angular-ui-router/release/angular-ui-router.min.js',
   'components/angulartics/dist/angulartics.min.js',
   'components/angulartics/dist/angulartics-ga.min.js',
@@ -48,7 +49,6 @@ var jsFilesToInject = [
   'components/angular-ui-select/dist/select.min.js',
   'components/angular-ui-utils/ui-utils.min.js',
   'components/angular-material/angular-material.min.js',
-  'components/angular-animate/angular-animate.min.js',
   'components/angular-aria/angular-aria.min.js',
   'components/angular-messages/angular-messages.min.js',
   'components/Chart.js/src/Chart.Core.js',

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -42,7 +42,7 @@
 
   <%- body %>
 
-  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.3/angular.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.4/angular.min.js"></script>
   <!--SCRIPTS-->
   <script src="/concat/production.js"></script>
   <!--SCRIPTS END-->


### PR DESCRIPTION
- Adds `publishCreate` and `publishUpdate` to Vimeo sync
- Prevents infinite digest loop when an editable field is an array (Vimeo tag field)
- Prevents errors if callback is not supplied in a `sailsSocket.sync` call