### PR TITLE
[#104235048] As a platform user, I would like the ability to edit the date on podcast episodes which are sync'd from Vimeo so that I can re-order my episodes as needed.

### DIFF
--- a/assets/features/podcast/podcastDetailView.html
+++ b/assets/features/podcast/podcastDetailView.html
@@ -71,7 +71,7 @@
             <p am-time-ago="media.date"></p>
           </div>
           <div class="episode-tools" flex="30">
-            <md-button class="md-mini md-primary" ng-click="editMedia($event, media.id)" ng-if="podcast.source === 1">Edit</md-button>
+            <md-button class="md-mini md-primary" ng-click="editMedia($event, media.id)">Edit</md-button>
             <md-button ng-disabled="true" class="md-mini">Embed</md-button>
           </div>
           <md-divider ng-if="!$last"></md-divider>

--- a/assets/features/podcast/podcastMediaController.js
+++ b/assets/features/podcast/podcastMediaController.js
@@ -3,6 +3,7 @@ angular.module('Bethel.podcast')
   function ($scope, $mdDialog, mediaId, $sce, sailsSocket, $http, $filter) {
 
   sailsSocket.get('/podcastmedia/' + mediaId).then(function (data) {
+    if (data.podcast.source === 2) $scope.vimeo = true;
     if (data.date) data.date = $filter('date')(data.date, 'mediumDate', 'UTC');
     $scope.media = data;
     $scope.media.url = $sce.trustAsResourceUrl('/podcast/embed/episode/' + data.id);

--- a/assets/features/podcast/podcastMediaView.html
+++ b/assets/features/podcast/podcastMediaView.html
@@ -6,7 +6,7 @@
     <div layout-padding>
 
       <md-input-container>
-        <label>{{ 'PODCAST.MEDIA.TITLE' | translate }}</label>
+        <label>{{ 'PODCAST.MEDIA.TITLE' | translate }}<span ng-if="vimeo"> (syncing from Vimeo)</span></label>
         <input type="text" disabled="{{ vimeo }}" ng-model="media.name" />
       </md-input-container>
 
@@ -31,7 +31,7 @@
       </md-autocomplete>
 
       <md-input-container>
-        <label>{{ 'PODCAST.MEDIA.DESCRIPTION' | translate }}</label>
+        <label>{{ 'PODCAST.MEDIA.DESCRIPTION' | translate }}<span ng-if="vimeo"> (syncing from Vimeo)</span></label>
         <textarea disabled="{{ vimeo }}" ng-model="media.description" columns="1" rows="3"></textarea>
       </md-input-container>
 

--- a/assets/features/podcast/podcastMediaView.html
+++ b/assets/features/podcast/podcastMediaView.html
@@ -7,7 +7,7 @@
 
       <md-input-container>
         <label>{{ 'PODCAST.MEDIA.TITLE' | translate }}<span ng-if="vimeo"> (syncing from Vimeo)</span></label>
-        <input type="text" disabled="{{ vimeo }}" ng-model="media.name" />
+        <input type="text" ng-disabled="vimeo" ng-model="media.name" />
       </md-input-container>
 
       <md-input-container>
@@ -30,9 +30,9 @@
         </md-not-found>
       </md-autocomplete>
 
-      <md-input-container>
+      <md-input-container >
         <label>{{ 'PODCAST.MEDIA.DESCRIPTION' | translate }}<span ng-if="vimeo"> (syncing from Vimeo)</span></label>
-        <textarea disabled="{{ vimeo }}" ng-model="media.description" columns="1" rows="3"></textarea>
+        <textarea ng-disabled="vimeo" ng-model="media.description" columns="1" rows="3"></textarea>
       </md-input-container>
 
       <div class="form-group" data-ng-if="ministry.url">

--- a/assets/features/podcast/podcastMediaView.html
+++ b/assets/features/podcast/podcastMediaView.html
@@ -1,18 +1,18 @@
 <md-dialog flex="50" class="podcast-media">
   <md-dialog-content class="sticky-container">
 
-    <iframe data-ng-src="{{ media.url }}" width="600" height="140" frameborder="0"></iframe>
+    <iframe ng-src="{{ media.url }}" width="600" height="140" frameborder="0"></iframe>
 
     <div layout-padding>
 
       <md-input-container>
         <label>{{ 'PODCAST.MEDIA.TITLE' | translate }}</label>
-        <input type="text" ng-model="media.name">
+        <input type="text" disabled="{{ vimeo }}" ng-model="media.name" />
       </md-input-container>
 
       <md-input-container>
         <label>Episode Date</label>
-        <input type="text" ng-model="media.date">
+        <input type="text" ng-model="media.date" />
       </md-input-container>
 
       <md-autocomplete
@@ -32,7 +32,7 @@
 
       <md-input-container>
         <label>{{ 'PODCAST.MEDIA.DESCRIPTION' | translate }}</label>
-        <textarea ng-model="media.description" columns="1" rows="3"></textarea>
+        <textarea disabled="{{ vimeo }}" ng-model="media.description" columns="1" rows="3"></textarea>
       </md-input-container>
 
       <div class="form-group" data-ng-if="ministry.url">


### PR DESCRIPTION
- Allows podcast episodes from Vimeo to be edited
- Disables the name and description field on the dialog
- Provides instructions to the user that explain why these fields are disabled