### PR TITLE
[#103737096] Any user can currently edit ministries using sails restful routes, even those they do not own.

### DIFF
--- a/api/policies/ministryOwned.js
+++ b/api/policies/ministryOwned.js
@@ -17,7 +17,7 @@ module.exports = function(req, res, next) {
 
     if (err) return res.badRequest();
 
-    if (object.ministry !== req.session.ministry) {
+    if (object.id !== req.session.ministry && object.ministry !== req.session.ministry) {
       return res.forbidden();
     }
 

--- a/config/policies.js
+++ b/config/policies.js
@@ -39,6 +39,11 @@ module.exports.policies = {
   	'create': true
   },
 
+  ministry: {
+    'update': 'ministryOwned',
+    'destroy': 'ministryOwned'
+  },
+
   podcast: {
     'feed': true,
     'embed': true,


### PR DESCRIPTION
Modifies ministryOwned policy to be usable to block or allow ministry editability