### PR TITLE
[#80256194] As a staff member I would like to be able to masquerade as a user so that I can replicate and resolve issues with their account.

### DIFF
--- a/api/controllers/SessionController.js
+++ b/api/controllers/SessionController.js
@@ -53,9 +53,20 @@ module.exports = {
       res.send({
         user: user,
         ministry: user.ministry,
-        isAdmin: user.hasRole('ROLE_SUPER_ADMIN')
+        isAdmin: user.hasRole('ROLE_SUPER_ADMIN') || req.session.isAdmin,
+        isMasquerading: req.session.isMasquerading
       });
     });
+  },
+
+  masquerade: function(req, res) {
+
+    req.session.user = req.param('user').id;
+    req.session.ministry = req.param('user').ministry;
+    req.session.isMasquerading = req.param('isMasquerading');
+    req.session.isAdmin = true;
+
+    res.ok();
   },
 
   destroy: function(req, res) {

--- a/api/controllers/SessionController.js
+++ b/api/controllers/SessionController.js
@@ -54,7 +54,7 @@ module.exports = {
         user: user,
         ministry: user.ministry,
         isAdmin: user.hasRole('ROLE_SUPER_ADMIN') || req.session.isAdmin,
-        isMasquerading: req.session.isMasquerading
+        previousUser: req.session.previousUser
       });
     });
   },
@@ -62,8 +62,8 @@ module.exports = {
   masquerade: function(req, res) {
 
     req.session.user = req.param('user').id;
-    req.session.ministry = req.param('user').ministry;
-    req.session.isMasquerading = req.param('isMasquerading');
+    req.session.ministry = req.param('user').ministry.id;
+    req.session.previousUser = req.param('previousUser');
     req.session.isAdmin = true;
 
     res.ok();

--- a/assets/app.js
+++ b/assets/app.js
@@ -91,7 +91,7 @@ angular.module('Bethel', [
     if (!newValue) return;
 
     var toast = $mdToast.simple()
-      .content(`Masquerading as ${$scope.user.name} from ${$scope.ministry.name}`)
+      .content('Masquerading as ' + $scope.user.name + ' from ' + $scope.ministry.name)
       .action('End')
       .highlightAction(false)
       .hideDelay(false)

--- a/assets/app.js
+++ b/assets/app.js
@@ -65,6 +65,7 @@ angular.module('Bethel', [
       $scope.user = response.user;
       $scope.ministry = response.ministry;
       $scope.isAdmin = response.isAdmin;
+      $scope.isMasquerading = response.isMasquerading;
 
       if (response.isAdmin) {
         $scope.navLinks.unshift({ title: 'Staff', icon: 'verified_user', url: 'staff.users' });
@@ -80,6 +81,17 @@ angular.module('Bethel', [
 
   $scope.toggleNav = function() {
     $scope.collapseNav = !$scope.collapseNav;
+  };
+
+  $scope.endMasquerade = function() {
+    var previousSession = $scope.isMasquerading;
+    previousSession.isMasquerading = false;
+
+    sailsSocket.post('/session/masquerade', previousSession).then(function () {
+      $scope.user = previousSession.user;
+      $scope.ministry = previousSession.ministry;
+      $scope.isMasquerading = null;
+    });
   };
 
 }]);

--- a/assets/features/staff/staffUserDetailController.js
+++ b/assets/features/staff/staffUserDetailController.js
@@ -60,6 +60,18 @@ angular.module('Bethel.staff')
     sailsSocket.get('/user/sendInvite/' + $scope.id).then($ctrl.getEmailConfirmation);
   };
 
+  $scope.masquerade = function() {
+
+    sailsSocket.post('/session/masquerade', {user: $scope.user, ministry: $scope.user.ministry, isMasquerading: true}).then(function () {
+      $scope.$root.user = $scope.user;
+      $scope.$root.ministry = $scope.user.ministry;
+    });
+
+    if (!$scope.$root.isMasquerading) {
+      $scope.$root.isMasquerading = {ministry: $scope.$root.ministry, user: $scope.$root.user};
+    }
+  };
+
   $ctrl.init();
 
 }]);

--- a/assets/features/staff/staffUserDetailController.js
+++ b/assets/features/staff/staffUserDetailController.js
@@ -61,15 +61,9 @@ angular.module('Bethel.staff')
   };
 
   $scope.masquerade = function() {
+    var previousUser = $scope.$root.previousUser || {user: $scope.$root.user, ministry: $scope.$root.ministry};
 
-    sailsSocket.post('/session/masquerade', {user: $scope.user, ministry: $scope.user.ministry, isMasquerading: true}).then(function () {
-      $scope.$root.user = $scope.user;
-      $scope.$root.ministry = $scope.user.ministry;
-    });
-
-    if (!$scope.$root.isMasquerading) {
-      $scope.$root.isMasquerading = {ministry: $scope.$root.ministry, user: $scope.$root.user};
-    }
+    sailsSocket.post('/session/masquerade', {user: $scope.user, previousUser: previousUser}).then(function () {window.location.reload();});
   };
 
   $ctrl.init();

--- a/assets/features/staff/staffUserDetailView.html
+++ b/assets/features/staff/staffUserDetailView.html
@@ -12,7 +12,12 @@
 
     <md-whiteframe flex class="md-whiteframe-z1 md-padding contact-info" layout="column">
 
-      <h3>User Details</h3>
+      <div layout="row" layout-align="space-between center">
+        <h3 flex>User Details</h3>
+        <div>
+          <md-button class="md-primary md-raised" ng-click="masquerade()">Masquerade</md-button>
+        </div>
+      </div>
 
       <md-input-container>
         <label>Email</label>

--- a/assets/features/staff/staffUserDetailView.html
+++ b/assets/features/staff/staffUserDetailView.html
@@ -15,7 +15,7 @@
       <div layout="row" layout-align="space-between center">
         <h3 flex>User Details</h3>
         <div>
-          <md-button class="md-primary md-raised" ng-click="masquerade()">Masquerade</md-button>
+          <md-button class="md-primary md-raised" ng-if="user.id !== $root.user.id && user.id !== previousUser.user.id" ng-click="masquerade()">Masquerade</md-button>
         </div>
       </div>
 

--- a/assets/shared/notifyService.js
+++ b/assets/shared/notifyService.js
@@ -1,16 +1,21 @@
 angular.module('Bethel.util').service('notifyService', ['$mdToast', function ($mdToast) {
 
+  this.beforeNotify = function(){};
+  this.afterNotify = function(){};
+
   this.commonAlerts = {
     saved: 'Your changes have been saved!',
   };
 
   this.showCommon = function(type) {
-    if (!this.commonAlerts[type]) return;
+    if (!this.commonAlerts[type] || !this.beforeNotify()) return;
 
     $mdToast.show($mdToast.simple()
       .content(this.commonAlerts[type])
       .position('bottom right')
       .hideDelay(3000));
+
+    this.afterNotify();
   };
 
 }]);

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -19,15 +19,6 @@
 
 <body layout="row">
 
-<!-- Position this better -->
-<div ng-if="isMasquerading" layout="row" layout-align="space-between center">
-  <p flex="70">Masquerading as {{user.name}} from {{user.ministry.name}}</p>
-  <div flex="20">
-    <md-button class="md-raised" ng-click="endMasquerade()">End Masquerade</md-button>
-  </div>
-  <div flex="10"></div>
-</div>
-
 <section layout="row" flex>
   <div id="outdated">
     <h6>Your browser is out of date!</h6>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -19,13 +19,23 @@
 
 <body layout="row">
 
+<!-- Position this better -->
+<div ng-if="isMasquerading" layout="row" layout-align="space-between center">
+  <p flex="70">Masquerading as {{user.name}} from {{user.ministry.name}}</p>
+  <div flex="20">
+    <md-button class="md-raised" ng-click="endMasquerade()">End Masquerade</md-button>
+  </div>
+  <div flex="10"></div>
+</div>
+
+<section layout="row" flex>
   <div id="outdated">
     <h6>Your browser is out of date!</h6>
     <p>You'll need a more recent browser to use Bethel. Click below for a few suggestions... <a id="btnUpdateBrowser" href="http://outdatedbrowser.com/">Update my browser now </a></p>
     <p class="last"><a href="#" id="btnCloseUpdateBrowser" title="Close">&times;</a></p>
   </div>
 
-  <md-sidenav class="md-sidenav-left md-whiteframe-z2" layout="column" md-component-id="left" md-is-locked-open="$mdMedia('gt-md')" ng-cloak ng-if="user" layout-fill>
+  <md-sidenav class="md-sidenav-left md-whiteframe-z2" layout="column" md-component-id="left" md-is-locked-open="$mdMedia('gt-md')" ng-cloak ng-if="user">
     <md-toolbar class="md-hue-2">
       <h1 class="md-toolbar-tools">Bethel</h1>
     </md-toolbar>
@@ -57,6 +67,7 @@
     function browserCheck(a){var b=window.onload;window.onload='function'!=typeof window.onload?a:function(){b&&b();a()}}
     browserCheck(function(){outdatedBrowser({bgColor:'#f25648',color:'#fff',lowerThan:'flex',languagePath:''})});
   </script>
+</section>
 
 </body>
 


### PR DESCRIPTION
- Adds basic masquerading functionality
- Switches user and ministry in session so staff is essentially logged in as user with all permissions
- Uses material toast to indicate masquerade status and enable ending of masquerade session