### PR TITLE
[#106813666] Update last login date when currentSession route is hit, so that we can track recent activity instead of actual logins.

### DIFF
--- a/api/controllers/SessionController.js
+++ b/api/controllers/SessionController.js
@@ -50,11 +50,19 @@ module.exports = {
       if (err || !user)
         return res.forbidden({ error: 'Please login at http://my.bethel.io' });
 
-      res.send({
+      var payload = {
         user: user,
         ministry: user.ministry,
         isAdmin: user.hasRole('ROLE_SUPER_ADMIN') || req.session.isAdmin,
         previousUser: req.session.previousUser
+      };
+
+      User.update(req.session.user, { lastLogin: new Date() }, function (err, user) {
+        if (err)
+          return res.forbidden({ error: 'Please login at http://my.bethel.io' });
+
+        payload.user.lastLogin = user.lastLogin;
+        res.send(payload);
       });
     });
   },

--- a/assets/js/embed.js
+++ b/assets/js/embed.js
@@ -2,13 +2,16 @@
   var VJSButton = videojs.getComponent('Button');
 
   var DownloadButton = videojs.extend(VJSButton, {
+    uuid: '',
     constructor: function(player, options) {
+      if (!player.options().uuid) return;
+      this.uuid = player.options().uuid;
       VJSButton.call(this, player, options);
       this.controlText('Download');
       this.addClass('vjs-download-button');
     },
     handleClick: function() {
-      window.location.href = '/podcastmedia/download/' + player.options().uuid;
+      window.location.href = '/podcastmedia/download/' + this.uuid;
     }
   });
 


### PR DESCRIPTION
This branched off of the latest development. It merged when I pulled even though I should have been up to date. So I don't think this includes anything it shouldn't but take a look at those other commits that tagged along with this one.