### PR TITLE
[#106173814] Video embed should include the MP4 version of the video as a fallback for Chrome until VJS HLS support is ready.

### DIFF
--- a/api/controllers/PodcastMediaController.js
+++ b/api/controllers/PodcastMediaController.js
@@ -25,7 +25,7 @@ module.exports = {
       }
 
       if (embed) {
-        var embedUrl = (media.variants && media.variants.hls) ? media.variants.hls : media.url;
+        var embedUrl = (req.query.variant === 'hls' && media.variants && media.variants.hls) ? media.variants.hls : media.url;
         return res.redirect(embedUrl);
       }
 

--- a/views/podcast/embed.ejs
+++ b/views/podcast/embed.ejs
@@ -28,6 +28,16 @@
       embedStyles += '.video-js.vjs-bethel-skin .vjs-progress-control .vjs-progress-holder{background:' + podcast.embedSettings.sliderColor + '}';
     }
   }
+
+  var posterImage;
+  if (episode.thumbnail) {
+    posterImage = episode.thumbnail;
+  }
+  else {
+    posterImage = 'https://images.bethel.io/images/';
+    posterImage += podcast.image ? podcast.image : 'DefaultPodcaster.png';
+    posterImage += '?crop=faces&fit=crop&w=140&h=140';
+  }
 %>
 <!DOCTYPE html>
 <html>
@@ -39,11 +49,12 @@
 </head>
 <body>
 
-  <<%= podcast.type %> id="embedded" class="video-js vjs-bethel-skin" uuid="<%= episode.id %>" <% if (podcast.embedSettings && podcast.embedSettings.feedUrl) { %>feed="<%= podcast.embedSettings.feedUrl %>" <% } %>controls poster="https://images.bethel.io/images/<%= podcast.image ? podcast.image : 'DefaultPodcaster.png' %>?crop=faces&fit=crop&w=140&h=140" preload="none">
-<% if (!episode.variants || !episode.variants.hls) { %>
+  <<%= podcast.type %> id="embedded" class="video-js vjs-bethel-skin" uuid="<%= episode.id %>" <% if (podcast.embedSettings && podcast.embedSettings.feedUrl) { %>feed="<%= podcast.embedSettings.feedUrl %>" <% } %>controls poster="<%= posterImage %>" preload="none">
+<% if (!episode.variants) { %>
     <source src="/podcastmedia/download/<%= episode.id %>?embed" type="<%= PodcastHelper.mimeTypeFromUrl(episode.url) %>" />
 <% } else { %>
-    <source src="/podcastmedia/download/<%= episode.id %>?embed" type="application/x-mpegURL" />
+    <% if (episode.variants.hls) { %><source src="/podcastmedia/download/<%= episode.id %>?variant=hls&embed" type="application/x-mpegURL" /><% } %>
+    <source src="/podcastmedia/download/<%= episode.id %>?variant=mp4&embed" type="video/mp4" />
 <% } %>
     <p class="vjs-no-js">Please enable JavaScript, and consider upgrading to a web browser that <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a></p>
   </<%= podcast.type %>>


### PR DESCRIPTION
- Adds MP4 fallback for Chrome and Firefox users
- Show the video poster when it is available on Vimeo episodes