### PR TITLE
[#106811546] Podcast stats are pulling from the current week, showing inaccurate large decreases in viewership over the past week.

### DIFF
--- a/api/controllers/PodcastController.js
+++ b/api/controllers/PodcastController.js
@@ -234,7 +234,7 @@ module.exports = {
   subscribers: function(req, res) {
     var statsDate = Number(moment().subtract(1, 'week').format('GGGGWW'));
 
-    Stats.find({ object: req.param('id'), type: 'podcast' }).sort('date desc').limit(24).exec(function (err, historical) {
+    Stats.find({ object: req.param('id'), type: 'podcast' }).sort('date desc').skip(1).limit(24).exec(function (err, historical) {
       var historicalStats = {};
       if (historical.length >= 1) {
         historical.forEach(function(historicalStat) {

--- a/assets/features/podcast/podcastDetailController.js
+++ b/assets/features/podcast/podcastDetailController.js
@@ -11,7 +11,8 @@ angular.module('Bethel.podcast')
   $scope.uploadProgress = 0;
   $scope.editing = false;
   $scope.subscriberCount = 0;
-  $scope.subscriberChange = 0;
+  $scope.subscriberDifference = 0;
+  $scope.subscriberPercentChange = 0;
 
   $scope.subscriberChart = {
     data: [[]],
@@ -52,8 +53,9 @@ angular.module('Bethel.podcast')
       $scope.subscriberChart.labels.push(moment().subtract(10 - i, 'weeks').format('MMM D'));
     }
     $scope.subscriberCount = $scope.subscriberChart.data[0].slice(-1)[0];
-    $scope.subscriberCompare = $scope.subscriberChart.data[0].slice(-2)[0]
-    $scope.subscriberChange = (($scope.subscriberCount - $scope.subscriberCompare) / $scope.subscriberCompare) * 100;
+    $scope.subscriberCompare = $scope.subscriberChart.data[0].slice(-2)[0];
+    $scope.subscriberDifference = $scope.subscriberCount - $scope.subscriberCompare;
+    $scope.subscriberPercentChange = Math.abs(($scope.subscriberDifference / $scope.subscriberCompare) * 100);
   };
 
   $scope.$watch('podcastStats', function (newValue) {
@@ -64,9 +66,10 @@ angular.module('Bethel.podcast')
       $scope.subscriberChart.data[0].push(subscribers);
       $scope.subscriberChart.labels.push(moment(String(week), 'YYYYw').format('MMM D'));
     });
-    $scope.subscriberCount = $scope.subscriberChart.data[0].slice(-2)[0] || 0;
-    $scope.subscriberCompare = $scope.subscriberChart.data[0].slice(-3)[0];
-    $scope.subscriberChange = (($scope.subscriberCount - $scope.subscriberCompare) / $scope.subscriberCompare) * 100;
+    $scope.subscriberCount = $scope.subscriberChart.data[0].slice(-1)[0] || 0;
+    $scope.subscriberCompare = $scope.subscriberChart.data[0].slice(-2)[0];
+    $scope.subscriberDifference = $scope.subscriberCount - $scope.subscriberCompare;
+    $scope.subscriberPercentChange = Math.abs(($scope.subscriberDifference / $scope.subscriberCompare) * 100);
 
     $ctrl.populateDemo();
   }, true);

--- a/assets/features/podcast/podcastDetailView.html
+++ b/assets/features/podcast/podcastDetailView.html
@@ -58,10 +58,10 @@
           <small>audience</small>
         </md-card-content>
       </md-card>
-      <md-card ng-class="subscriberChange > 1 ? 'good' : 'bad'" ng-if="subscriberChange !== 0">
+      <md-card ng-class="subscriberDifference > 0 ? 'good' : 'bad'" ng-if="subscriberPercentChange !== 0">
         <md-card-content>
-          <strong>{{ subscriberChange | number : 1 }}%</strong><br />
-          <small>{{ subscriberChange > 1 ? 'increase' : 'decrease' }}</small>
+          <strong>{{ subscriberPercentChange | number : 1 }}%</strong><br />
+          <small>{{ subscriberDifference > 0 ? 'increase' : 'decrease' }}</small>
         </md-card-content>
       </md-card>
     </div>


### PR DESCRIPTION
- Excludes most recent week from podcast stats
- Displays absolute value of calculated podcast subscriber increase or
decrease
- Corrects comparison error that was displaying podcasts with percent
increase between 0 and 1 as decreasing