### PR TITLE
[#77684662] As a platform user I would like to be able to delete existing episodes that have been uploaded to my podcast.

### DIFF
--- a/api/controllers/PodcastController.js
+++ b/api/controllers/PodcastController.js
@@ -87,7 +87,7 @@ module.exports = {
   },
 
   edit: function (req, res) {
-    Podcast.findOne(req.param('id')).populate('media').populate('service').exec(function foundPodcast(err, podcast) {
+    Podcast.findOne(req.param('id')).populate('media', { deleted: { $ne: true } }).populate('service').exec(function foundPodcast(err, podcast) {
       if (err || !podcast || !podcast.id) return next(err);
 
       var uploadForm = S3Upload.prepare('images/podcast/tmp');
@@ -142,7 +142,7 @@ module.exports = {
   },
 
   feed: function (req, res) {
-    Podcast.findOne(req.param('id')).populate('ministry').populate('media', { sort: { date: 0 } }).exec(function (err, podcast) {
+    Podcast.findOne(req.param('id')).populate('ministry').populate('media', { deleted: { $ne: true} }, { sort: { date: 0 } }).exec(function (err, podcast) {
       if (err) return res.serverError(err);
       if (!podcast) return res.notFound();
 

--- a/api/controllers/PodcastMediaController.js
+++ b/api/controllers/PodcastMediaController.js
@@ -73,6 +73,27 @@ module.exports = {
         });
       });
     });
+  },
+
+  destroy: function(req, res) {
+    PodcastMedia.findOne(req.param('id')).exec(function(err, media) {
+      if (err) return res.serverError(err);
+      if (media.podcast.type === 2) {
+        PodcastMedia.destroy(req.param('id'), function deletedMedia(err) {
+          if (err) {
+            sails.log.error(err);
+            return res.serverError(err);
+          }
+          // @TODO: Destroy media stored in S3 if podcast media is hosted on Bethel Cloud
+          res.ok();
+        });
+      } else {
+        PodcastMedia.update(req.param('id'), { deleted: true }, function(err, updated) {
+          if (err) return res.serverError(err);
+          res.ok(updated);
+        });
+      }
+    });
   }
 
 };

--- a/api/models/PodcastMedia.js
+++ b/api/models/PodcastMedia.js
@@ -66,6 +66,10 @@ module.exports = {
 
     podcast: {
       model: 'podcast'
+    },
+
+    deleted: {
+      type: 'boolean'
     }
 
 	},

--- a/assets/features/podcast/_podcastStyles.less
+++ b/assets/features/podcast/_podcastStyles.less
@@ -12,6 +12,9 @@ md-dialog.podcast-media {
     margin-bottom: 20px;
     width: 100%;
   }
+  .md-icon-button {
+    margin: 0;
+  }
 }
 
 md-dialog.wizard.podcast {

--- a/assets/features/podcast/podcastDetailView.html
+++ b/assets/features/podcast/podcastDetailView.html
@@ -93,11 +93,11 @@
           <p ng-if="uploading">Way to go! Your first podcast episode is uploading...</p>
         </md-list-item>
         <md-list-item class="md-2-line md-no-proxy" layout="row" ng-repeat="media in podcast.media | orderBy : 'date' : true">
-          <div class="md-list-item-text" flex="70">
+          <div class="md-list-item-text" flex-gt-lg="60" flex="50">
             <h3> {{ media.name }} </h3>
             <p am-time-ago="media.date"></p>
           </div>
-          <div class="episode-tools" flex="30">
+          <div class="episode-tools" flex-gt-lg="40" flex="50">
             <md-button class="md-mini md-primary" ng-click="editMedia($event, media.id)">Edit</md-button>
             <md-button class="md-mini" ng-click="embedMedia($event, media.id)">Embed</md-button>
           </div>

--- a/assets/features/podcast/podcastMediaController.js
+++ b/assets/features/podcast/podcastMediaController.js
@@ -20,6 +20,10 @@ angular.module('Bethel.podcast')
       });
   };
 
+  $scope.deletePodcastEpisode = function($event, media) {
+    $mdDialog.hide({deleteMedia: true, media: media});
+  };
+
   $scope.save = function() {
     sailsSocket.put('/podcastmedia/' + mediaId, {
       name: $scope.media.name,

--- a/assets/features/podcast/podcastMediaView.html
+++ b/assets/features/podcast/podcastMediaView.html
@@ -43,6 +43,9 @@
     </div>
   </md-dialog-content>
   <div class="md-actions" layout="row">
+    <md-button ng-click="deletePodcastEpisode($event, media)" class="md-icon-button" aria-label="Delete Episode">
+      <md-icon md-light md-menu-origin>delete</md-icon>
+    </md-button>
     <span flex></span>
     <md-button ng-click="cancel()">Cancel</md-button>
     <md-button ng-click="save()" class="md-primary">Save Changes</md-button>

--- a/assets/shared/confirmDeleteService.js
+++ b/assets/shared/confirmDeleteService.js
@@ -1,0 +1,18 @@
+angular.module('Bethel.util')
+.service('confirmDelete', ['$mdDialog', function ($mdDialog) {
+
+  return function (options) {
+
+    var defaultTitle = 'Are you sure?',
+        defaultMessage = 'This ' + (options.type || 'item') + ' will be permanently deleted. This action cannot be undone.';
+
+    var confirm = $mdDialog.confirm()
+      .title(options.title ? options.title : defaultTitle)
+      .content(options.message ? options.message : defaultMessage)
+      .ok('Delete')
+      .cancel('Cancel');
+
+    return $mdDialog.show(confirm);
+  };
+
+}]);

--- a/config/policies.js
+++ b/config/policies.js
@@ -56,7 +56,9 @@ module.exports.policies = {
     'download': true,
     'stat': true,
     'subscribe': true,
-    'related': true
+    'related': true,
+    'update': 'ministryOwned',
+    'destroy': 'ministryOwned'
   },
 
   staff: {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "angular-material": "^0.10.1",
     "angular-messages": "^1.5.0",
     "angular-moment": "^0.10.3",
-    "angular-sails-socket": "^0.1.1",
+    "angular-sails-socket": "^0.2.2",
     "angular-translate": "^2.5.2",
     "angular-ui-router": "^0.2.15",
     "angular-wizard": "^0.5.5",

--- a/test/angular/_podcast.angular.js
+++ b/test/angular/_podcast.angular.js
@@ -54,7 +54,7 @@ window.test.podcast = function() {
           });
           return deferred.promise;
         });
-        ctrl.getSubscriberCount({ id: 1 });
+        ctrl.getPodcastMeta({ id: 1 });
         expect(sailsSocket.get).toHaveBeenCalledWith('/_analytics/podcastSubscribers/1');
         scope.$digest();
         expect(scope.statistics.Ghy2).toEqual(123);


### PR DESCRIPTION
- Filters out “deleted” episodes in podcast episode list
- Add deleted property to podcastMedia model
- Add trash icon to podcast media modal
- Add confirmDeleteService using mdDialog confirm modal
- Add deletePodcastEpisode podcast scope action
- Add destroy method to PodcastMediaController
- Modification to deletePodcastEpisode method to handle vimeo videos differently
- Add ministryOwned policy to podcastMedia destroy route
- Add podcast episode filter to podcast feed route